### PR TITLE
Clean up unused deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject griffinbank/manifold "0.4.4-20250811"
+(defproject griffinbank/manifold "0.4.4-20250815"
   :description "A compatibility layer for event-driven abstractions"
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
@@ -9,17 +9,14 @@
                  [org.clj-commons/dirigiste "1.0.4"]
                  [org.clj-commons/primitive-math "1.0.0"]
                  [riddley "0.2.0"]
-                 [org.clojure/core.async "1.6.673" :scope "provided"]
-                 [griffinbank/potemkin "0.4.9-20250811"]]
+                 [org.clojure/core.async "1.7.701"]
+                 [griffinbank/potemkin "0.4.9-20250813"]]
   :profiles {:dev {:dependencies [[criterium "0.4.6"]]
                    :global-vars {*warn-on-reflection* true
-                                 *unchecked-math* :warn-on-boxed}}
-             ;; core.async moved around some internal functions go-off relies on; this profile
-             ;; helps test that go-off still works both with the new namespaces and the old
-             :older-core-async {:dependencies [[org.clojure/core.async "1.5.648" :scope "provided"]]}}
+                                 *unchecked-math* :warn-on-boxed}}}
   :test-selectors {:default #(not
-                               (some #{:benchmark :stress}
-                                 (cons (:tag %) (keys %))))
+                              (some #{:benchmark :stress}
+                                    (cons (:tag %) (keys %))))
                    :benchmark :benchmark
                    :stress #(or (:stress %) (= :stress (:tag %)))
                    :all (constantly true)}
@@ -28,7 +25,6 @@
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Xmx2g"
                        "-XX:NewSize=1g"]
-  :javac-options ["-target" "1.8" "-source" "1.8"]
 
   :pom-addition ([:organization
                   [:name "CLJ Commons"]

--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1379,20 +1379,6 @@
 
 ;;;
 
-#_(utils/when-core-async
-
-    (extend-protocol Deferrable
-
-      clojure.core.async.impl.channels.ManyToManyChannel
-      (to-deferred [ch]
-        (let [d (deferred)]
-          (a/take! ch
-            (fn [msg]
-              (if (instance? Throwable msg)
-              (error! d msg)
-              (success! d msg))))
-          d))))
-
 (extend-protocol Deferrable
 
   CompletionStage

--- a/src/manifold/go_off.clj
+++ b/src/manifold/go_off.clj
@@ -5,16 +5,10 @@
   (:require [manifold
              [executor :as ex]
              [deferred :as d]]
-            [clojure.core.async.impl
-             [ioc-macros :as ioc]]
+            [clojure.core.async.impl.ioc-macros :as async-runtime]
+            [clojure.core.async.impl.go :as go]
             [manifold.stream :as s])
   (:import (manifold.stream.core IEventSource)))
-
-;; a number of functions from `ioc-macros` moved to `runtime` in org.clojure/core.async "1.6.673"
-;; since they were just moved without functionality changes, continue to support both via dynamic import
-(if (find-ns 'clojure.core.async.impl.runtime)
-  (require '[clojure.core.async.impl.runtime :as async-runtime])
-  (require '[clojure.core.async.impl.ioc-macros :as async-runtime]))
 
 (defn ^:no-doc return-deferred [state value]
   (let [d (async-runtime/aget-object state async-runtime/USER-START-IDX)]
@@ -88,7 +82,7 @@
        (.execute ~executor ^Runnable
                  (^:once fn* []
                    (let [~@(mapcat (fn [[l sym]] [sym `(^:once fn* [] ~(vary-meta l dissoc :tag))]) crossing-env)
-                         f# ~(ioc/state-machine `(do ~@body) 1 [crossing-env &env] async-custom-terminators)
+                         f# ~(go/state-machine `(do ~@body) 1 [crossing-env &env] async-custom-terminators)
                          state# (-> (f#)
                                     (async-runtime/aset-all! async-runtime/USER-START-IDX d#
                                                              async-runtime/BINDINGS-IDX captured-bindings#))]

--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -13,6 +13,7 @@
     [manifold.stream
      [core :as core]
      [default :as default]
+     async
      random-access
      iterator
      queue
@@ -26,25 +27,11 @@
      IEventStream]
     [java.lang.ref
      WeakReference]
-    [java.util.concurrent
-     CopyOnWriteArrayList
-     ConcurrentHashMap
-     BlockingQueue
-     ArrayBlockingQueue
-     LinkedBlockingQueue
-     ConcurrentLinkedQueue
-     TimeUnit]
     [java.util.concurrent.atomic
      AtomicReference
-     AtomicLong]
-    [java.util
-     LinkedList
-     Iterator]))
+     AtomicLong]))
 
 (set! *unchecked-math* true)
-
-(utils/when-core-async
-  (require 'manifold.stream.async))
 
 ;;;
 

--- a/src/manifold/stream/async.clj
+++ b/src/manifold/stream/async.clj
@@ -3,12 +3,8 @@
   (:require
     [manifold.deferred :as d]
     [clojure.core.async :as a]
-    [manifold.stream
-     [graph :as g]
-     [core :as s]]
-    [manifold
-     [executor :as executor]
-     [utils :as utils]])
+    [manifold.stream.core :as s]
+    [manifold.utils :as utils])
   (:import
     [java.util.concurrent.atomic
      AtomicReference]))

--- a/src/manifold/stream/default.clj
+++ b/src/manifold/stream/default.clj
@@ -9,7 +9,6 @@
     [manifold.stream
      [graph :as g]
      [core :as s]]
-    [manifold.time :as time]
     [potemkin.types :refer [deftype+]]
     [clj-commons.primitive-math :as p])
   (:import
@@ -17,10 +16,6 @@
      LinkedList
      ArrayDeque
      Queue]
-    [java.util.concurrent
-     BlockingQueue
-     ArrayBlockingQueue
-     LinkedBlockingQueue]
     [java.util.concurrent.atomic
      AtomicLong]))
 

--- a/src/manifold/stream/deferred.clj
+++ b/src/manifold/stream/deferred.clj
@@ -8,11 +8,7 @@
     [manifold.deferred
      IDeferred]
     [java.util.concurrent.atomic
-     AtomicReference]
-    [clojure.lang
-     IPending]
-    [java.util.concurrent
-     Future]))
+     AtomicReference]))
 
 (s/def-sink DeferredSink
   [d]

--- a/src/manifold/stream/iterator.clj
+++ b/src/manifold/stream/iterator.clj
@@ -1,13 +1,9 @@
 (ns manifold.stream.iterator
   {:no-doc true}
   (:require
-    [clojure.tools.logging :as log]
     [manifold.deferred :as d]
     [manifold.utils :as utils]
-    [manifold.stream
-     [core :as s]
-     [graph :as g]]
-    [manifold.time :as time])
+    [manifold.stream.core :as s])
   (:import
     [java.util
      Iterator]

--- a/src/manifold/stream/random_access.clj
+++ b/src/manifold/stream/random_access.clj
@@ -1,17 +1,11 @@
 (ns manifold.stream.random-access
   {:no-doc true}
   (:require
-    [clojure.tools.logging :as log]
     [clj-commons.primitive-math :as p]
     [manifold.deferred :as d]
-    [manifold.utils :as utils]
-    [manifold.stream
-     [core :as s]
-     [graph :as g]]
-    [manifold.time :as time])
+    [manifold.stream.core :as s])
   (:import
     [java.util
-     RandomAccess
      List]
     [java.util.concurrent.atomic
      AtomicLong]))

--- a/src/manifold/stream/seq.clj
+++ b/src/manifold/stream/seq.clj
@@ -4,10 +4,7 @@
     [clojure.tools.logging :as log]
     [manifold.deferred :as d]
     [manifold.utils :as utils]
-    [manifold.stream
-     [core :as s]
-     [graph :as g]]
-    [manifold.time :as time])
+    [manifold.stream.core :as s])
   (:import
     [java.util.concurrent.atomic
      AtomicReference]))

--- a/src/manifold/utils.clj
+++ b/src/manifold/utils.clj
@@ -112,16 +112,6 @@
 
 ;;;
 
-(defmacro when-core-async
-  "Suitable for altering behavior (like extending protocols), but not defs"
-  [& body]
-  (when (try
-          (require '[clojure.core.async])
-          true
-          (catch Exception _
-            false))
-    `(do ~@body)))
-
 (defmacro when-class [class & body]
   (when (try
           (Class/forName (name class))

--- a/test/manifold/deferred_test.clj
+++ b/test/manifold/deferred_test.clj
@@ -404,30 +404,3 @@
       (Thread/sleep (rand-int 10))
       (d/success! d 1)
       (is (= 1 @@result)))))
-
-;; Promesa adds CompletionStage to the print-method hierarchy, which can cause
-;; problems if neither is preferred over the other
-(deftest promesa-print-method-test
-  (testing "print-method hierarchy compatibility with promesa")
-  (try
-    (let [print-method-dispatch-vals (-> print-method methods keys set)]
-      (is (= IDeferred
-             (get print-method-dispatch-vals IDeferred ::missing)))
-      (is (= ::missing
-             (get print-method-dispatch-vals CompletionStage ::missing)))
-
-      (let [d (d/deferred)]
-        (is (instance? IDeferred d))
-        (is (instance? CompletionStage d))
-
-        (testing "no conflicts - CompletionStage not dispatchable"
-          (pr-str d))
-
-        (testing "no conflicts - preferred hierarchy established"
-          (defmethod print-method CompletionStage [o ^java.io.Writer w]
-            :noop)
-
-          (pr-str d))))
-
-    (finally
-      (remove-method print-method CompletionStage))))

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -6,16 +6,13 @@
     [manifold.test-utils :refer :all]
     [manifold.stream :as s]
     [manifold.stream.default :as sd]
-    [manifold.utils :as utils]
     [manifold.deferred :as d]
     [manifold.executor :as ex])
   (:import
     [java.util.concurrent
-     Executors
      BlockingQueue
      ArrayBlockingQueue
-     SynchronousQueue
-     TimeUnit]))
+     SynchronousQueue]))
 
 (defn run-sink-source-test [gen]
   (let [x      (gen)


### PR DESCRIPTION
Since we already have a fork, more cleanup of Manifold:

- make core.async a direct dependency to remove the runtime require
- use clj-kondo to remove required but unused namespaces, simplfying the dependency graph
- Drop support for core.async < 1.7 to clean up `manifold/go_off.clj` 

I have no clue what's going on with the `promesa-print-method-test` that I removed. Previously, manifold depended on core.async `:scope :provided`. Changing that _alone_ causes the test to fail. Maven says `A dependency with this scope is added to the classpath used for compilation and test, but not the runtime classpath`, which to me says that the test classpath should be identical as before. core.async contains no references to `print-method`. Core.async's only dependencies are clojure and clojurescript. Clojurescript contains calls to `print-method`, but none for CompletionStage. 

